### PR TITLE
use upstream espeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,7 @@
 
 ## Install
 
-install espeak with catalan phonemizer support, a binary should be placed at `/usr/local/lib/libespeak-ng.so`
-
-```bash
-git clone https://github.com/projecte-aina/espeak-ng
-cd ./espeak-ng
-./autogen.sh
-./configure
-make
-sudo make install
-```
+> **NOTE**: you need latest version of espeak-ng for proper [catalan support](https://github.com/espeak-ng/espeak-ng/pull/1681), depending on your distro package versions you might need to compile it from source
 
 the plugin can be installed with pip
 

--- a/ovos_tts_plugin_matxa_multispeaker_cat/__init__.py
+++ b/ovos_tts_plugin_matxa_multispeaker_cat/__init__.py
@@ -13,18 +13,6 @@ class MatxaCatalanTTSPlugin(TTS):
 
     def __init__(self, lang="ca-es", config=None):
         super(MatxaCatalanTTSPlugin, self).__init__(lang=lang, config=config, audio_ext='wav')
-        bin_file = self.config.get("espeak_bin", "/usr/local/lib/libespeak-ng.so")
-        if not os.path.isfile(bin_file):
-            raise FileNotFoundError("please follow instructions to install the catalan espeak fork\n"
-                                    "   git clone https://github.com/projecte-aina/espeak-ng\n"
-                                    "   cd ./espeak-ng\n"
-                                    "   ./autogen.sh\n"
-                                    "   ./configure\n"
-                                    "   make\n"
-                                    "   sudo make install\n"
-                                    "the file '/usr/local/lib/libespeak-ng.so' should be created if the install succeeds")
-        EspeakBackend.set_library(bin_file)
-
         MODEL_PATH_matxa_MEL_ALL = f"{os.path.dirname(__file__)}/matcha_multispeaker_cat_all_opset_15_10_steps.onnx"
         MODEL_PATH_VOCOS = f"{os.path.dirname(__file__)}/mel_spec_22khz_cat.onnx"
         VOCODER_CONFIG_PATH = f"{os.path.dirname(__file__)}/config.yaml"


### PR DESCRIPTION
closes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Streamlined installation instructions for the `espeak-ng` library, highlighting the importance of using the latest version for Catalan phonemizer support.

- **Refactor**
	- Removed dependency checks and initialization code related to the `espeak_bin` file in the `MatxaCatalanTTSPlugin` class, simplifying the setup process for text-to-speech functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->